### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.5.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 ## 0.4.1
 
 - Raise Exception if MySQL returns an error

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ When running actions, you can pass in the name of a connection, e.g.
 Alternatively, when running an action, you can pass in the hostname, db, user, passwd
 parameters.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``select`` - Run a DB query

--- a/actions/insert.yaml
+++ b/actions/insert.yaml
@@ -1,6 +1,6 @@
 ---
   name: "insert"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Insert data into a MySQL database"
   enabled: true
   entry_point: "insert.py"

--- a/actions/select.yaml
+++ b/actions/select.yaml
@@ -1,6 +1,6 @@
 ---
   name: "select"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Select data from a MySQL database"
   enabled: true
   entry_point: "select.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description : Mysql integration pack
 keywords :
   - mysql
   - database
-version : 0.4.1
+version : 0.5.0
 author : st2-dev
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.