### PR TITLE
Fix Unicode issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.5.2
+
+- Fix Unicode issues with mysql.insert
+
 # 0.5.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Query and Update MySQL
 
+## Pre-Requisites
+
+You must install the `libmysqlclient-dev` system package, e.g. with `sudo apt install libmysqlclient-dev`
+
 ## Configuration
 
 Copy the example configuration in [mysql.yaml.example](./mysql.yaml.example)

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -19,7 +19,6 @@ class MySQLInsertAction(MySQLBaseAction):
     def insert(self, table, data):
         columns = self._list_to_string(data.keys(), quotes=False)
         values = self._list_to_string(data.values())
-        values = values.decode('utf-8')
 
         query = "INSERT INTO {} ({}) VALUES ({})".format(table.encode('utf-8'), columns, values)
         c = self.db.cursor()

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -19,8 +19,9 @@ class MySQLInsertAction(MySQLBaseAction):
     def insert(self, table, data):
         columns = self._list_to_string(data.keys(), quotes=False)
         values = self._list_to_string(data.values())
+        values = values.decode('utf-8')
 
-        query = u"INSERT INTO {} ({}) VALUES ({})".format(table.encode('utf-8'), columns, values)
+        query = "INSERT INTO {} ({}) VALUES ({})".format(table.encode('utf-8'), columns, values)
         c = self.db.cursor()
         try:
             c.execute(query)

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description : Mysql integration pack
 keywords :
   - mysql
   - database
-version: 0.5.1
+version: 0.5.2
 author : st2-dev
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
There was an issue with adding Unicode data:

```shell
extreme@EWC:/opt/stackstorm/packs/mysql/actions$ st2 run mysql.insert connection=localhost table=authors data='{"name": "leo2", "organization": "上海"}'
.
id: 5b2d73c199c96b2277df1a04
status: failed
parameters:
  connection: localhost
  data:
    name: leo2
    organization: "上海"
  table: authors
result:
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):
  File "/opt/stackstorm/runners/python_runner/python_runner/python_action_wrapper.py", line 320, in <module>
    obj.run()
  File "/opt/stackstorm/runners/python_runner/python_runner/python_action_wrapper.py", line 179, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/mysql/actions/insert.py", line 17, in run
    return self.insert(table, data)
  File "/opt/stackstorm/packs/mysql/actions/insert.py", line 23, in insert
    query = u"INSERT INTO {} ({}) VALUES ({})".format(table.encode('utf-8'), columns, values)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 1: ordinal not in range(128)
"
  stdout: ''
extreme@EWC:/opt/stackstorm/packs/mysql/actions$
```

With this fix in place, this now works:
```shell
extreme@EWC:/opt/stackstorm/packs/mysql/actions$ st2 run mysql.insert connection=localhost table=authors data='{"name": "leo", "organization": "上海"}'
.
id: 5b2d73d599c96b2277df1a07
status: succeeded
parameters:
  connection: localhost
  data:
    name: leo
    organization: "上海"
  table: authors
result:
  exit_code: 0
  result: 1
  stderr: ''
  stdout: ''
extreme@EWC:/opt/stackstorm/packs/mysql/actions$ st2 run mysql.select connection=localhost query="select * from authors"
.
id: 5b2d73dd99c96b2277df1a0a
status: succeeded
parameters:
  connection: localhost
  query: select * from authors
result:
  exit_code: 0
  result:
  - name: lindsay
    organization: foobar
  - name: leo
    organization: "上海"
  stderr: 'No handlers could be found for logger "st2.st2common.util.loader"
    '
  stdout: ''
extreme@EWC:/opt/stackstorm/packs/mysql/actions$
```

Fixes #7 

Note that it was not necessary to add `charset=utf-8` as per #7 - this is the default charset. 