### PR TITLE
added six for iteritems() 2.7 and 3.6 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changelog
+# 0.6.2
+
+- update iteritems() to be compatible with python 3.6 and backwards compatible with 2.7
+
 # 0.6.1
 
 - Password fields are now secrets

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -1,7 +1,8 @@
 import MySQLdb
 import MySQLdb.cursors
-from datetime import datetime
+import six
 
+from datetime import datetime
 from st2common.runners.base_action import Action
 
 __all__ = [
@@ -56,7 +57,7 @@ class MySQLBaseAction(Action):
         rows = []
         for row in cursor.fetchall():
             d = {}
-            for k, v in row.iteritems():
+            for k, v in six.iteritems(row):
                 if isinstance(v, datetime):
                     d[k] = str(v)
                 else:

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description : Mysql integration pack
 keywords :
   - mysql
   - database
-version: 0.6.1
+version: 0.6.2
 author : st2-dev
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Actions failing in St2 on Ubuntu 18.04

```
  "stderr": "Class \"epoll\" doesn't implement required \"run\" method from the base class
Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/loader.py\", line 173, in register_plugin
    _register_plugin(plugin_base_class, klass)
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/loader.py\", line 120, in _register_plugin
    _validate_methods(plugin_base_class, plugin_impl)
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/loader.py\", line 116, in _validate_methods
    raise IncompatiblePluginException(message % (plugin_klass.__name__, method))
st2common.exceptions.plugins.IncompatiblePluginException: Class \"epoll\" doesn't implement required \"run\" method from the base class
Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 333, in <module>
    obj.run()
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 192, in run
    output = action.run(**self._parameters)
  File \"/opt/stackstorm/packs/mysql/actions/select.py\", line 19, in run
    return self.select(query, data, key)
  File \"/opt/stackstorm/packs/mysql/actions/select.py\", line 30, in select
    output = self._format_results(c)
  File \"/opt/stackstorm/packs/mysql/actions/lib/base.py\", line 59, in _format_results
    for k, v in row.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
```

Adding `six` and updating `row.iteritems()` => `six.iteritems(row)`

Tested on st2 3.2 Ubuntu 18.04, and st2 3.2 on Ubuntu 16.04