### PR TITLE
Fixing compatibility for Str/Byte data (Py 2.7 -> 3.x). #20

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changelog
+# 0.6.3
+
+- Addresses #20 - Fixing compatibility for Str/Byte data (Py 2.7 -> 3.x).
+
 # 0.6.2
 
 - update iteritems() to be compatible with python 3.6 and backwards compatible with 2.7

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -1,4 +1,5 @@
 import MySQLdb
+import six
 
 from lib.base import MySQLBaseAction
 
@@ -20,7 +21,8 @@ class MySQLInsertAction(MySQLBaseAction):
         columns = self._list_to_string(data.keys(), quotes=False)
         values = self._list_to_string(data.values())
 
-        query = "INSERT INTO {} ({}) VALUES ({})".format(table.encode('utf-8'), columns, values)
+        query = "INSERT INTO {} ({}) VALUES ({})".format(
+            six.ensure_str(table.encode('utf-8')), columns, values)
         c = self.db.cursor()
         try:
             c.execute(query)

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -38,7 +38,8 @@ class MySQLBaseAction(Action):
                                cursorclass=cursorclass)
 
     def _escape_string(self, item):
-        return MySQLdb.escape_string(unicode(item).encode('utf-8'))  # pylint: disable=no-member
+        return six.ensure_str(
+            MySQLdb.escape_string(unicode(item).encode('utf-8')))  # pylint: disable=no-member
 
     def _list_to_string(self, data, quotes=True):
         output = ""

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ description : Mysql integration pack
 keywords :
   - mysql
   - database
-version: 0.6.2
+version: 0.6.3
 author : st2-dev
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Tested Insert, Select, and Update on `Ubuntu 18.04.5 LTS` with Python `3.6.9`

Addresses issue raised in #20 (Big thanks to Amanda11)
